### PR TITLE
fix: added fix for comma dangle for <T,> types

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,16 @@ import * as eslint from 'typescript-eslint'
 export const codemaskConfig = eslint.config(
     js.configs.recommended,
     {
+        files: ['**/*.tsx'],
+        languageOptions: {
+            parserOptions: {
+                ecmaFeatures: {
+                    jsx: true,
+                },
+            },
+        },
+    },
+    {
         ignores: ['.eslintrc.js', 'node_modules', '@typescript-eslint/parser'],
         languageOptions: {
             globals: {


### PR DESCRIPTION
before 
![image](https://github.com/user-attachments/assets/c4559a6a-95e4-4e52-9834-1ff2d51d5807)

after
![image](https://github.com/user-attachments/assets/a51b79db-1d99-43ee-bff2-0cde9c88f0ca)

